### PR TITLE
Spice-up the "Skills" page

### DIFF
--- a/src/lib/components/skill_section.svelte
+++ b/src/lib/components/skill_section.svelte
@@ -3,7 +3,6 @@
     import type { SkillEntry } from "$lib/skills";
     import { Link } from "lucide-svelte";
 
-    export let description: string = "";
     export let name: string;
 
     export let skills: SkillEntry[];
@@ -50,7 +49,10 @@
     </div>
 </Modal>
 
-<section id={`skills:${sectionId}`} class="border-cat-base border rounded-lg my-2 relative">
+<section
+    id={`skills:${sectionId}`}
+    class="bg-cat-crust/80 border-cat-base border rounded-lg my-4 relative shadow-xl"
+>
     <h3 class="text-lg text-center flex justify-center items-center gap-x-1 group">
         <a class="cursor-pointer" href={`#skills:${sectionId}`}>
             <Link class="size-4 invisible group-hover:visible" />
@@ -59,15 +61,11 @@
         {name}
     </h3>
 
-    {#if description}
-        <p class="text-xs text-center text-cat-subtext0/80 mb-1">{description}</p>
-    {/if}
-
-    <ul class="w-full flex flex-wrap items-center justify-center gap-x-2 gap-y-1 mb-3">
+    <ul class="w-full flex flex-wrap items-center justify-center gap-x-2 gap-y-1 mb-3 px-2">
         {#each skills as skill}
             <li id={`skills:${sectionId}:${skill.name.toLowerCase().replaceAll(" ", "-")}`}>
                 <button
-                    class="text-sm text-cat-crust bg-cat-pink hover:bg-cat-peach select-none cursor-pointer transition-colors px-2 rounded-md"
+                    class="text-cat-crust bg-cat-pink hover:bg-cat-peach select-none cursor-pointer transition-colors px-4 py-1 rounded-md"
                     on:click={() => {
                         selectedSkill = skill;
                         showSkillModal = true;

--- a/src/routes/(sections)/+layout.svelte
+++ b/src/routes/(sections)/+layout.svelte
@@ -1,4 +1,27 @@
-<div class="absolute top-0 left-0 w-screen h-screen overflow-hidden bg-cat-crust -z-10" />
+<script lang="ts">
+    import { renderGridBackground } from "$lib/grid_background";
+    import { onDestroy, onMount } from "svelte";
+    import { browser } from "$app/environment";
+
+    let canvasElement: HTMLCanvasElement;
+    let onDestroyDisposeFn = () => {};
+
+    if (browser) {
+        onDestroy(onDestroyDisposeFn);
+
+        onMount(() => {
+            const { render, dispose } = renderGridBackground(canvasElement);
+            onDestroyDisposeFn = dispose;
+            render();
+        });
+    }
+</script>
+
+<canvas
+    id="infinite-grid-renderer"
+    class="absolute top-0 left-0 w-full h-full overflow-hidden"
+    bind:this={canvasElement}
+/>
 
 <header class="fixed top-0 left-0 w-screen py-2 px-4 flex justify-between items-center">
     <nav class="flex items-center gap-x-2">

--- a/src/routes/(sections)/+layout.svelte
+++ b/src/routes/(sections)/+layout.svelte
@@ -19,11 +19,11 @@
 
 <canvas
     id="infinite-grid-renderer"
-    class="absolute top-0 left-0 w-full h-full overflow-hidden -z-20"
+    class="absolute top-0 left-0 w-full h-full overflow-hidden"
     bind:this={canvasElement}
 />
 
-<header class="fixed top-0 left-0 w-screen py-2 px-4 flex justify-between items-center">
+<header class="fixed top-0 left-0 w-screen py-2 px-4 flex justify-between items-center z-10">
     <nav class="flex items-center gap-x-2">
         <a
             class="navigation-link font-bold text-cat-mauve after:bg-cat-mauve hover:text-cat-peach hover:after:bg-cat-peach"
@@ -58,6 +58,6 @@
     </nav>
 </header>
 
-<main class="absolute top-0 left-0 w-full h-full text-sm -z-10">
+<main class="absolute top-0 left-0 w-full h-full text-sm">
     <slot />
 </main>

--- a/src/routes/(sections)/+layout.svelte
+++ b/src/routes/(sections)/+layout.svelte
@@ -19,7 +19,7 @@
 
 <canvas
     id="infinite-grid-renderer"
-    class="absolute top-0 left-0 w-full h-full overflow-hidden"
+    class="fixed top-0 left-0 w-full h-full overflow-hidden"
     bind:this={canvasElement}
 />
 

--- a/src/routes/(sections)/+layout.svelte
+++ b/src/routes/(sections)/+layout.svelte
@@ -19,7 +19,7 @@
 
 <canvas
     id="infinite-grid-renderer"
-    class="absolute top-0 left-0 w-full h-full overflow-hidden"
+    class="absolute top-0 left-0 w-full h-full overflow-hidden -z-20"
     bind:this={canvasElement}
 />
 
@@ -58,6 +58,6 @@
     </nav>
 </header>
 
-<main class="absolute top-0 left-0 w-full h-full text-sm">
+<main class="absolute top-0 left-0 w-full h-full text-sm -z-10">
     <slot />
 </main>

--- a/src/routes/(sections)/+layout.svelte
+++ b/src/routes/(sections)/+layout.svelte
@@ -58,6 +58,6 @@
     </nav>
 </header>
 
-<main class="absolute top-0 left-0 w-full text-sm mt-14">
+<main class="absolute top-0 left-0 w-full h-full text-sm">
     <slot />
 </main>

--- a/src/routes/(sections)/contact/+page.svelte
+++ b/src/routes/(sections)/contact/+page.svelte
@@ -3,38 +3,42 @@
     import { toastsStore } from "$lib/stores";
 </script>
 
-<h2 class="text-center text-2xl">Contact</h2>
+<div class="w-full h-full flex flex-col justify-center items-center">
+    <h2 class="text-center text-2xl">Contact</h2>
 
-<div class="flex flex-col justify-center items-center">
-    You can contact me at the links below:
-
-    <button
-        id="contact/personal-email-link"
-        class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
-        on:click={() => {
-            navigator.clipboard.writeText("pereiswell@gmail.com");
-            toastsStore.push("Copied text to clipboard!");
-        }}
+    <div
+        class="flex flex-col justify-center items-center bg-cat-crust/80 border-cat-base border rounded-lg relative shadow-xl p-4"
     >
-        <AtSign />
-        pereiswell@gmail.com
-    </button>
+        You can contact me at the links below:
 
-    <a
-        id="contact/personal-linkedin-link"
-        href="https://www.linkedin.com/in/pere-wells/"
-        class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
-    >
-        <LinkedinIcon />
-        Pere Wells
-    </a>
+        <button
+            id="contact/personal-email-link"
+            class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
+            on:click={() => {
+                navigator.clipboard.writeText("pereiswell@gmail.com");
+                toastsStore.push("Copied text to clipboard!");
+            }}
+        >
+            <AtSign />
+            pereiswell@gmail.com
+        </button>
 
-    <a
-        id="contact/personal-github-link"
-        href="https://github.com/c1m50c"
-        class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
-    >
-        <GithubIcon />
-        @c1m50c
-    </a>
+        <a
+            id="contact/personal-linkedin-link"
+            href="https://www.linkedin.com/in/pere-wells/"
+            class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
+        >
+            <LinkedinIcon />
+            Pere Wells
+        </a>
+
+        <a
+            id="contact/personal-github-link"
+            href="https://github.com/c1m50c"
+            class="flex gap-x-1 items-center text-cat-blue hover:text-cat-sky transition-colors"
+        >
+            <GithubIcon />
+            @c1m50c
+        </a>
+    </div>
 </div>

--- a/src/routes/(sections)/skills/+page.svelte
+++ b/src/routes/(sections)/skills/+page.svelte
@@ -12,21 +12,11 @@
     <h2 class="text-center text-2xl">Skills</h2>
 
     <div class="px-16">
-        <SkillSection
-            name="Languages"
-            description="Collection of programming, command and markup languages that I have experience writing in."
-            skills={LANGUAGE_SKILLS}
-        />
-
-        <SkillSection
-            name="Libraries & Frameworks"
-            description="Collection of libraries and frameworks that I have experience using."
-            skills={LIBRARY_AND_FRAMEWORK_SKILLS}
-        />
+        <SkillSection name="Languages" skills={LANGUAGE_SKILLS} />
+        <SkillSection name="Libraries & Frameworks" skills={LIBRARY_AND_FRAMEWORK_SKILLS} />
 
         <SkillSection
             name="Technologies, Tools & Services"
-            description="Collection of technologies, tools and services that I have experience working with."
             skills={TECHNOLOGY_TOOLS_AND_SERVICE_SKILLS}
         />
     </div>

--- a/src/routes/(sections)/skills/+page.svelte
+++ b/src/routes/(sections)/skills/+page.svelte
@@ -8,24 +8,26 @@
     } from "$lib/skills";
 </script>
 
-<h2 class="text-center text-2xl">Skills</h2>
+<div class="w-full h-full flex flex-col justify-center items-center">
+    <h2 class="text-center text-2xl">Skills</h2>
 
-<div class="px-16">
-    <SkillSection
-        name="Languages"
-        description="Collection of programming, command and markup languages that I have experience writing in."
-        skills={LANGUAGE_SKILLS}
-    />
+    <div class="px-16">
+        <SkillSection
+            name="Languages"
+            description="Collection of programming, command and markup languages that I have experience writing in."
+            skills={LANGUAGE_SKILLS}
+        />
 
-    <SkillSection
-        name="Libraries & Frameworks"
-        description="Collection of libraries and frameworks that I have experience using."
-        skills={LIBRARY_AND_FRAMEWORK_SKILLS}
-    />
+        <SkillSection
+            name="Libraries & Frameworks"
+            description="Collection of libraries and frameworks that I have experience using."
+            skills={LIBRARY_AND_FRAMEWORK_SKILLS}
+        />
 
-    <SkillSection
-        name="Technologies, Tools & Services"
-        description="Collection of technologies, tools and services that I have experience working with."
-        skills={TECHNOLOGY_TOOLS_AND_SERVICE_SKILLS}
-    />
+        <SkillSection
+            name="Technologies, Tools & Services"
+            description="Collection of technologies, tools and services that I have experience working with."
+            skills={TECHNOLOGY_TOOLS_AND_SERVICE_SKILLS}
+        />
+    </div>
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,7 @@
 
 <canvas
     id="infinite-grid-renderer"
-    class="absolute top-0 left-0 w-full h-full overflow-hidden"
+    class="fixed top-0 left-0 w-full h-full overflow-hidden"
     bind:this={canvasElement}
 />
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,17 +2,20 @@
     import { renderGridBackground } from "$lib/grid_background";
     import Peresonal from "$lib/components/peresonal.svelte";
     import { onDestroy, onMount } from "svelte";
+    import { browser } from "$app/environment";
 
     let canvasElement: HTMLCanvasElement;
     let onDestroyDisposeFn = () => {};
 
-    onDestroy(onDestroyDisposeFn);
+    if (browser) {
+        onDestroy(onDestroyDisposeFn);
 
-    onMount(() => {
-        const { render, dispose } = renderGridBackground(canvasElement);
-        onDestroyDisposeFn = dispose;
-        render();
-    });
+        onMount(() => {
+            const { render, dispose } = renderGridBackground(canvasElement);
+            onDestroyDisposeFn = dispose;
+            render();
+        });
+    }
 </script>
 
 <canvas


### PR DESCRIPTION
## Description

Completes #10, spices-up the "Skills" page and part of the "Contact" page.

## Commits

- Use `renderGridBackground` on all pages
- Center "Skills" page
- Move "Skills" page to a card-based layout
- Ensure `+layout.svelte` headers have priority over page content
- Place `z-index` tags in `+layout.svelte` only on the `header`
- Make `infinite-grid-renderer`s use `fixed` positioning
- Center "Contact" page while we're at it
